### PR TITLE
Searching for test state in class hierarchy.

### DIFF
--- a/src/main/java/com/googlecode/yatspec/junit/SpecListener.java
+++ b/src/main/java/com/googlecode/yatspec/junit/SpecListener.java
@@ -74,19 +74,24 @@ public class SpecListener implements AfterAllCallback, AfterEachMethodAdapter, T
     protected Optional<TestState> getOptionalTestState(Object testInstance) {
         Class<?> clazz = testInstance.getClass();
         while (clazz != null) {
-            Optional<TestState> optionalField = Optional.ofNullable(clazz)
-                    .map(Class::getDeclaredFields)
-                    .stream().flatMap(Stream::of)
-                    .filter(field -> field.getType() == TestState.class)
-                    .map(field -> getField(testInstance, field))
-                    .filter(Objects::nonNull)
-                    .map(TestState.class::cast)
-                    .findFirst();
-
-            if (optionalField.isEmpty()) clazz = clazz.getSuperclass();
-            else return optionalField;
+            Optional<TestState> optionalTestState = extractTestStateIfExists(testInstance, clazz);
+            if (optionalTestState.isPresent()) {
+                return optionalTestState;
+            }
+            clazz = clazz.getSuperclass();
         }
         return Optional.empty();
+    }
+
+    private Optional<TestState> extractTestStateIfExists(Object testInstance, Class<?> clazz) {
+        return Optional.ofNullable(clazz)
+                .map(Class::getDeclaredFields).stream()
+                .flatMap(Stream::of)
+                .filter(field -> field.getType() == TestState.class)
+                .map(field -> getField(testInstance, field))
+                .filter(Objects::nonNull)
+                .map(TestState.class::cast)
+                .findFirst();
     }
 
     private Object getField(Object testInstance, Field field) {

--- a/src/test/java/com/googlecode/yatspec/junit/SequenceDiagramExtensionTest.java
+++ b/src/test/java/com/googlecode/yatspec/junit/SequenceDiagramExtensionTest.java
@@ -18,6 +18,11 @@ class SequenceDiagramExtensionTest {
     }
 
     @Test
+    void noExceptionWhenTestStateIsFoundInSuperClass() {
+        sequenceDiagramExtension.postProcessTestInstance(new ClassWithNestedTestState(), null);
+    }
+
+    @Test
     void throwsAnExceptionIfNoTestStateFieldExistsInTest() {
         throwsIllegalStateException(new ClassWithNoTestState());
     }
@@ -48,4 +53,7 @@ class SequenceDiagramExtensionTest {
         @SuppressWarnings("unused")
         private final TestState testState = new TestState();
     }
+
+    public static class ClassWithNestedTestState extends AnotherTestClass { }
+    public static class AnotherTestClass extends ClassWithTestState { }
 }


### PR DESCRIPTION
Hey Nick,

Made a change to access test state from super class hierarchy. I don't like having the use of a `while` loop in there - I feel like it's ugly but couldn't find a better working solution after trying a few different things. 

Feel free to try and improve - i'd be interested to see how I could have done differently/better.

Tested this usecase with following code setup and it worked as intended:
```
public class ExampleTest extends SpecificationTest {
    @Test
    void exampleTest() {
        testState.log("Message", "Hello");
        assertThat(testState.getType("Message", String.class)).isEqualTo("Hello");
    }
}
```

```
@ExtendWith(SequenceDiagramExtension.class)
public class SpecificationTest implements WithCustomResultListeners {

    protected final TestState testState = new TestState();

    @Override
    public Collection<SpecResultListener> getResultListeners() throws Exception {
        return List.of();
    }
}
```