### PR TITLE
Refactor: Take advantage of polymorphism with SpecListener

### DIFF
--- a/src/main/java/com/googlecode/yatspec/junit/SequenceDiagramExtension.java
+++ b/src/main/java/com/googlecode/yatspec/junit/SequenceDiagramExtension.java
@@ -1,12 +1,7 @@
 package com.googlecode.yatspec.junit;
 
-import com.googlecode.yatspec.plugin.sequencediagram.SequenceDiagramGenerator;
-import com.googlecode.yatspec.sequence.Participant;
-import com.googlecode.yatspec.state.givenwhenthen.TestState;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -14,8 +9,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static java.util.Arrays.stream;
-import static java.util.Collections.emptyList;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+import com.googlecode.yatspec.plugin.sequencediagram.SequenceDiagramGenerator;
+import com.googlecode.yatspec.plugin.sequencediagram.SvgWrapper;
+import com.googlecode.yatspec.rendering.html.DontHighlightRenderer;
+import com.googlecode.yatspec.rendering.html.HtmlResultRenderer;
+import com.googlecode.yatspec.rendering.html.index.HtmlIndexRenderer;
+import com.googlecode.yatspec.sequence.Participant;
+import com.googlecode.yatspec.state.givenwhenthen.TestState;
 
 public class SequenceDiagramExtension extends SpecListener implements TestInstancePostProcessor, BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
@@ -69,5 +74,18 @@ public class SequenceDiagramExtension extends SpecListener implements TestInstan
                 throw new RuntimeException(e);
             }
         };
+    }
+
+    @Override
+    protected WithCustomResultListeners createDefaultResultListeners() {
+        return defaultSequenceDiagramResultListener();
+    }
+
+    private WithCustomResultListeners defaultSequenceDiagramResultListener() {
+        return () -> List.of(
+                new HtmlResultRenderer().
+                        withCustomRenderer(SvgWrapper.class, new DontHighlightRenderer()),
+                new HtmlIndexRenderer()
+        );
     }
 }

--- a/src/main/java/com/googlecode/yatspec/junit/SpecListener.java
+++ b/src/main/java/com/googlecode/yatspec/junit/SpecListener.java
@@ -1,18 +1,13 @@
 package com.googlecode.yatspec.junit;
 
-import com.googlecode.yatspec.plugin.sequencediagram.SvgWrapper;
 import com.googlecode.yatspec.rendering.ScenarioNameRenderer;
 import com.googlecode.yatspec.rendering.ScenarioNameRendererFactory;
-import com.googlecode.yatspec.rendering.html.DontHighlightRenderer;
-import com.googlecode.yatspec.rendering.html.HtmlResultRenderer;
-import com.googlecode.yatspec.rendering.html.index.HtmlIndexRenderer;
 import com.googlecode.yatspec.state.Result;
 import com.googlecode.yatspec.state.Scenario;
 import com.googlecode.yatspec.state.ScenarioName;
 import com.googlecode.yatspec.state.TestResult;
 import com.googlecode.yatspec.state.givenwhenthen.TestState;
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
@@ -106,25 +101,12 @@ public class SpecListener implements AfterAllCallback, AfterEachMethodAdapter, T
     private WithCustomResultListeners resultListeners(Object testInstance) {
         if (testInstance instanceof WithCustomResultListeners) {
             return (WithCustomResultListeners) testInstance;
-        } else if (hasSequenceDiagramExtension(testInstance)) {
-            return defaultSequenceDiagramResultListener();
-        } else {
-            return new DefaultResultListeners();
         }
+        return createDefaultResultListeners();
     }
 
-    private WithCustomResultListeners defaultSequenceDiagramResultListener() {
-        return () -> List.of(
-                new HtmlResultRenderer().
-                        withCustomRenderer(SvgWrapper.class, new DontHighlightRenderer()),
-                new HtmlIndexRenderer()
-        );
-    }
-
-    private boolean hasSequenceDiagramExtension(Object testInstance) {
-        if (null == testInstance) return false;
-        ExtendWith annotation = testInstance.getClass().getAnnotation(ExtendWith.class);
-        return asList(annotation.value()).contains(SequenceDiagramExtension.class);
+    protected WithCustomResultListeners createDefaultResultListeners() {
+        return new DefaultResultListeners();
     }
 
     private static class MethodNameWithArguments {


### PR DESCRIPTION
Sometimes its not possible to use the `@ExtendWith(SequenceDiagramExtension.class)` annotation on a test class. This occurs when the class has a need for another Extension which needs constructor arguments. In that case, instead of using the annotation, we need to use:
```
@RegisterExtension
static AnotherExtension anotherExtension = new AnotherExtension(x,y);
```
This isn't compatible with annotations - you have to use one or the other.

Thus, we need to replace the `@ExtendWith(SequenceDiagramExtension.class)` with:
```
@RegisterExtension
static SequenceDiagramExtension sequenceDiagramExtension = new SequenceDiagramExtension();
```

When we do this, the test in SpecListener to see if the test has been annotated with `@ExtendWith(SequenceDiagramExtension.class)` will return false, and the code doesn't work as intended.

However, SpecListener is subclassed by SequenceDiagramExtension, thus we can remove the need for the test. Thats what this PR is...